### PR TITLE
Task 1: Unify endpoint URL handling

### DIFF
--- a/oura_api_client/api/client.py
+++ b/oura_api_client/api/client.py
@@ -71,7 +71,7 @@ class OuraClient:
         """Make a request to the Oura API.
 
         Args:
-            endpoint (str): The API endpoint to call
+            endpoint (str): The API endpoint to call (should start with /)
             params (dict, optional): Query parameters for the request
             method (str): HTTP method to use (default: GET)
 
@@ -81,6 +81,14 @@ class OuraClient:
         Raises:
             requests.exceptions.RequestException: If the API request fails
         """
+        # Ensure endpoint starts with /
+        if not endpoint.startswith('/'):
+            endpoint = f"/{endpoint}"
+        
+        # Remove any duplicate /v2 prefix if present
+        if endpoint.startswith('/v2/'):
+            endpoint = endpoint[3:]  # Remove '/v2' prefix
+        
         url = f"{self.BASE_URL}{endpoint}"
 
         if method.upper() == "GET":

--- a/oura_api_client/api/daily_activity.py
+++ b/oura_api_client/api/daily_activity.py
@@ -33,7 +33,7 @@ class DailyActivity(BaseRouter):
         }
         params = {k: v for k, v in params.items() if v is not None}
         response = self.client._make_request(
-            "/v2/usercollection/daily_activity", params=params
+            "/usercollection/daily_activity", params=params
         )
         return DailyActivityResponse(**response)
 
@@ -50,6 +50,6 @@ class DailyActivity(BaseRouter):
             DailyActivityModel: Response containing daily activity data.
         """
         response = self.client._make_request(
-            f"/v2/usercollection/daily_activity/{document_id}"
+            f"/usercollection/daily_activity/{document_id}"
         )
         return DailyActivityModel(**response)

--- a/oura_api_client/api/daily_cardiovascular_age.py
+++ b/oura_api_client/api/daily_cardiovascular_age.py
@@ -37,7 +37,7 @@ class DailyCardiovascularAge(BaseRouter):
         }
         params = {k: v for k, v in params.items() if v is not None}
         response = self.client._make_request(
-            "/v2/usercollection/daily_cardiovascular_age", params=params
+            "/usercollection/daily_cardiovascular_age", params=params
         )
         return DailyCardiovascularAgeResponse(**response)
 
@@ -55,6 +55,6 @@ class DailyCardiovascularAge(BaseRouter):
                 cardiovascular age data.
         """
         response = self.client._make_request(
-            f"/v2/usercollection/daily_cardiovascular_age/{document_id}"
+            f"/usercollection/daily_cardiovascular_age/{document_id}"
         )
         return DailyCardiovascularAgeModel(**response)

--- a/oura_api_client/api/daily_readiness.py
+++ b/oura_api_client/api/daily_readiness.py
@@ -36,7 +36,7 @@ class DailyReadiness(BaseRouter):
         }
         params = {k: v for k, v in params.items() if v is not None}
         response = self.client._make_request(
-            "/v2/usercollection/daily_readiness", params=params
+            "/usercollection/daily_readiness", params=params
         )
         return DailyReadinessResponse(**response)
 
@@ -53,6 +53,6 @@ class DailyReadiness(BaseRouter):
             DailyReadinessModel: Response containing daily readiness data.
         """
         response = self.client._make_request(
-            f"/v2/usercollection/daily_readiness/{document_id}"
+            f"/usercollection/daily_readiness/{document_id}"
         )
         return DailyReadinessModel(**response)

--- a/oura_api_client/api/daily_resilience.py
+++ b/oura_api_client/api/daily_resilience.py
@@ -36,7 +36,7 @@ class DailyResilience(BaseRouter):
         }
         params = {k: v for k, v in params.items() if v is not None}
         response = self.client._make_request(
-            "/v2/usercollection/daily_resilience", params=params
+            "/usercollection/daily_resilience", params=params
         )
         return DailyResilienceResponse(**response)
 
@@ -53,6 +53,6 @@ class DailyResilience(BaseRouter):
             DailyResilienceModel: Response containing daily resilience data.
         """
         response = self.client._make_request(
-            f"/v2/usercollection/daily_resilience/{document_id}"
+            f"/usercollection/daily_resilience/{document_id}"
         )
         return DailyResilienceModel(**response)

--- a/oura_api_client/api/daily_sleep.py
+++ b/oura_api_client/api/daily_sleep.py
@@ -36,7 +36,7 @@ class DailySleep(BaseRouter):
         }
         params = {k: v for k, v in params.items() if v is not None}
         response = self.client._make_request(
-            "/v2/usercollection/daily_sleep", params=params
+            "/usercollection/daily_sleep", params=params
         )
         return DailySleepResponse(**response)
 
@@ -51,6 +51,6 @@ class DailySleep(BaseRouter):
             DailySleepModel: Response containing daily sleep data.
         """
         response = self.client._make_request(
-            f"/v2/usercollection/daily_sleep/{document_id}"
+            f"/usercollection/daily_sleep/{document_id}"
         )
         return DailySleepModel(**response)

--- a/oura_api_client/api/daily_spo2.py
+++ b/oura_api_client/api/daily_spo2.py
@@ -36,7 +36,7 @@ class DailySpo2(BaseRouter):  # Renamed class to DailySpo2
         }
         params = {k: v for k, v in params.items() if v is not None}
         response = self.client._make_request(
-            "/v2/usercollection/daily_spo2", params=params
+            "/usercollection/daily_spo2", params=params
         )
         return DailySpO2Response(**response)
 
@@ -53,6 +53,6 @@ class DailySpo2(BaseRouter):  # Renamed class to DailySpo2
             DailySpO2Model: Response containing daily SpO2 data.
         """
         response = self.client._make_request(
-            f"/v2/usercollection/daily_spo2/{document_id}"
+            f"/usercollection/daily_spo2/{document_id}"
         )
         return DailySpO2Model(**response)

--- a/oura_api_client/api/daily_stress.py
+++ b/oura_api_client/api/daily_stress.py
@@ -36,7 +36,7 @@ class DailyStress(BaseRouter):
         }
         params = {k: v for k, v in params.items() if v is not None}
         response = self.client._make_request(
-            "/v2/usercollection/daily_stress", params=params
+            "/usercollection/daily_stress", params=params
         )
         return DailyStressResponse(**response)
 
@@ -51,6 +51,6 @@ class DailyStress(BaseRouter):
             DailyStressModel: Response containing daily stress data.
         """
         response = self.client._make_request(
-            f"/v2/usercollection/daily_stress/{document_id}"
+            f"/usercollection/daily_stress/{document_id}"
         )
         return DailyStressModel(**response)

--- a/oura_api_client/api/enhanced_tag.py
+++ b/oura_api_client/api/enhanced_tag.py
@@ -36,7 +36,7 @@ class EnhancedTag(BaseRouter):
         }
         params = {k: v for k, v in params.items() if v is not None}
         response = self.client._make_request(
-            "/v2/usercollection/enhanced_tag", params=params
+            "/usercollection/enhanced_tag", params=params
         )
         return EnhancedTagResponse(**response)
 
@@ -51,6 +51,6 @@ class EnhancedTag(BaseRouter):
             EnhancedTagModel: Response containing enhanced_tag data.
         """
         response = self.client._make_request(
-            f"/v2/usercollection/enhanced_tag/{document_id}"
+            f"/usercollection/enhanced_tag/{document_id}"
         )
         return EnhancedTagModel(**response)

--- a/oura_api_client/api/rest_mode_period.py
+++ b/oura_api_client/api/rest_mode_period.py
@@ -36,7 +36,7 @@ class RestModePeriod(BaseRouter):
         }
         params = {k: v for k, v in params.items() if v is not None}
         response = self.client._make_request(
-            "/v2/usercollection/rest_mode_period", params=params
+            "/usercollection/rest_mode_period", params=params
         )
         return RestModePeriodResponse(**response)
 
@@ -53,6 +53,6 @@ class RestModePeriod(BaseRouter):
             RestModePeriodModel: Response containing rest_mode_period data.
         """
         response = self.client._make_request(
-            f"/v2/usercollection/rest_mode_period/{document_id}"
+            f"/usercollection/rest_mode_period/{document_id}"
         )
         return RestModePeriodModel(**response)

--- a/oura_api_client/api/ring_configuration.py
+++ b/oura_api_client/api/ring_configuration.py
@@ -49,7 +49,7 @@ class RingConfiguration(BaseRouter):
         final_params = {k: v for k, v in params.items() if v is not None}
 
         response = self.client._make_request(
-            "/v2/usercollection/ring_configuration",
+            "/usercollection/ring_configuration",
             params=final_params if final_params else None
         )
         return RingConfigurationResponse(**response)
@@ -67,6 +67,6 @@ class RingConfiguration(BaseRouter):
             RingConfigurationModel: Response containing ring configuration data.
         """
         response = self.client._make_request(
-            f"/v2/usercollection/ring_configuration/{document_id}"
+            f"/usercollection/ring_configuration/{document_id}"
         )
         return RingConfigurationModel(**response)

--- a/oura_api_client/api/session.py
+++ b/oura_api_client/api/session.py
@@ -36,7 +36,7 @@ class Session(BaseRouter):
         }
         params = {k: v for k, v in params.items() if v is not None}
         response = self.client._make_request(
-            "/v2/usercollection/session", params=params
+            "/usercollection/session", params=params
         )
         return SessionResponse(**response)
 
@@ -51,6 +51,6 @@ class Session(BaseRouter):
             SessionModel: Response containing session data.
         """
         response = self.client._make_request(
-            f"/v2/usercollection/session/{document_id}"
+            f"/usercollection/session/{document_id}"
         )
         return SessionModel(**response)

--- a/oura_api_client/api/sleep.py
+++ b/oura_api_client/api/sleep.py
@@ -39,7 +39,7 @@ class Sleep(BaseRouter):  # Renamed class to Sleep
         params = {k: v for k, v in params.items() if v is not None}
         # Corrected endpoint URL from daily_sleep to sleep
         response = self.client._make_request(
-            "/v2/usercollection/sleep", params=params
+            "/usercollection/sleep", params=params
         )
         return SleepResponse(**response)
 
@@ -57,6 +57,6 @@ class Sleep(BaseRouter):  # Renamed class to Sleep
         """
         # Corrected endpoint URL from daily_sleep to sleep
         response = self.client._make_request(
-            f"/v2/usercollection/sleep/{document_id}"
+            f"/usercollection/sleep/{document_id}"
         )
         return SleepModel(**response)

--- a/oura_api_client/api/sleep_time.py
+++ b/oura_api_client/api/sleep_time.py
@@ -36,7 +36,7 @@ class SleepTime(BaseRouter):
         }
         params = {k: v for k, v in params.items() if v is not None}
         response = self.client._make_request(
-            "/v2/usercollection/sleep_time", params=params
+            "/usercollection/sleep_time", params=params
         )
         return SleepTimeResponse(**response)
 
@@ -58,6 +58,6 @@ class SleepTime(BaseRouter):
         # sleep_time. Proceeding with the assumption it might exist or
         # for future compatibility.
         response = self.client._make_request(
-            f"/v2/usercollection/sleep_time/{document_id}"
+            f"/usercollection/sleep_time/{document_id}"
         )
         return SleepTimeModel(**response)

--- a/oura_api_client/api/tag.py
+++ b/oura_api_client/api/tag.py
@@ -33,7 +33,7 @@ class Tag(BaseRouter):
         }
         params = {k: v for k, v in params.items() if v is not None}
         response = self.client._make_request(
-            "/v2/usercollection/tag", params=params
+            "/usercollection/tag", params=params
         )
         return TagResponse(**response)
 
@@ -48,6 +48,6 @@ class Tag(BaseRouter):
             TagModel: Response containing tag data.
         """
         response = self.client._make_request(
-            f"/v2/usercollection/tag/{document_id}"
+            f"/usercollection/tag/{document_id}"
         )
         return TagModel(**response)

--- a/oura_api_client/api/vo2_max.py
+++ b/oura_api_client/api/vo2_max.py
@@ -33,7 +33,7 @@ class Vo2Max(BaseRouter):
         }
         params = {k: v for k, v in params.items() if v is not None}
         response = self.client._make_request(
-            "/v2/usercollection/vO2_max", params=params
+            "/usercollection/vO2_max", params=params
         )
         return Vo2MaxResponse(**response)
 
@@ -48,6 +48,6 @@ class Vo2Max(BaseRouter):
             Vo2MaxModel: Response containing VO2 max data.
         """
         response = self.client._make_request(
-            f"/v2/usercollection/vO2_max/{document_id}"
+            f"/usercollection/vO2_max/{document_id}"
         )
         return Vo2MaxModel(**response)

--- a/oura_api_client/api/webhook.py
+++ b/oura_api_client/api/webhook.py
@@ -46,7 +46,7 @@ class Webhook(BaseRouter):
         """
         headers = self._get_webhook_headers()
         response_data = self.client._make_request(
-            "/v2/webhook/subscription",
+            "/webhook/subscription",
             headers=headers
         )
         # API returns a list of subscriptions directly
@@ -77,7 +77,7 @@ class Webhook(BaseRouter):
             verification_token=verification_token,
         )
         response_data = self.client._make_request(
-            "/v2/webhook/subscription",
+            "/webhook/subscription",
             method="POST",
             json_data=request_body.model_dump(
                 by_alias=True
@@ -95,7 +95,7 @@ class Webhook(BaseRouter):
         """
         headers = self._get_webhook_headers()
         response_data = self.client._make_request(
-            f"/v2/webhook/subscription/{subscription_id}",
+            f"/webhook/subscription/{subscription_id}",
             headers=headers
         )
         return WebhookSubscriptionModel(**response_data)
@@ -123,7 +123,7 @@ class Webhook(BaseRouter):
             data_type=data_type,
         )
         response_data = self.client._make_request(
-            f"/v2/webhook/subscription/{subscription_id}",
+            f"/webhook/subscription/{subscription_id}",
             method="PUT",
             json_data=request_body.model_dump(
                 by_alias=True, exclude_none=True
@@ -139,7 +139,7 @@ class Webhook(BaseRouter):
         """
         headers = self._get_webhook_headers()
         self.client._make_request(
-            f"/v2/webhook/subscription/{subscription_id}",
+            f"/webhook/subscription/{subscription_id}",
             method="DELETE",
             headers=headers
         )
@@ -160,7 +160,7 @@ class Webhook(BaseRouter):
         #      headers['Content-Type'] = 'application/json'
 
         response_data = self.client._make_request(
-            f"/v2/webhook/subscription/renew/{subscription_id}",
+            f"/webhook/subscription/renew/{subscription_id}",
             method="PUT",
             headers=headers
             # No json_data for this specific renew endpoint as per typical

--- a/oura_api_client/api/workout.py
+++ b/oura_api_client/api/workout.py
@@ -33,7 +33,7 @@ class Workout(BaseRouter):
         }
         params = {k: v for k, v in params.items() if v is not None}
         response = self.client._make_request(
-            "/v2/usercollection/workout", params=params
+            "/usercollection/workout", params=params
         )
         return WorkoutResponse(**response)
 
@@ -48,6 +48,6 @@ class Workout(BaseRouter):
             WorkoutModel: Response containing workout data.
         """
         response = self.client._make_request(
-            f"/v2/usercollection/workout/{document_id}"
+            f"/usercollection/workout/{document_id}"
         )
         return WorkoutModel(**response)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -181,7 +181,7 @@ class TestDailyActivity(unittest.TestCase):
         # if client.get is not available
         actual_call_url = mock_get.call_args[0][0]
         base_url = self.client.BASE_URL
-        expected_url = f"{base_url}/v2/usercollection/daily_activity"
+        expected_url = f"{base_url}/usercollection/daily_activity"
         self.assertTrue(actual_call_url.endswith(expected_url))
 
         called_params = mock_get.call_args[1]['params']
@@ -215,7 +215,7 @@ class TestDailyActivity(unittest.TestCase):
         )
         actual_call_url = mock_get.call_args[0][0]
         base_url = self.client.BASE_URL
-        expected_url = f"{base_url}/v2/usercollection/daily_activity"
+        expected_url = f"{base_url}/usercollection/daily_activity"
         self.assertTrue(actual_call_url.endswith(expected_url))
 
         called_params = mock_get.call_args[1]['params']
@@ -283,7 +283,7 @@ class TestDailyActivity(unittest.TestCase):
 
         actual_call_url = mock_get.call_args[0][0]
         base_url = self.client.BASE_URL
-        expected_url = f"{base_url}/v2/usercollection/daily_activity/{document_id}"
+        expected_url = f"{base_url}/usercollection/daily_activity/{document_id}"
         self.assertTrue(actual_call_url.endswith(expected_url))
 
         called_params = mock_get.call_args[1]['params']
@@ -362,7 +362,7 @@ class TestDailySleep(unittest.TestCase):
         self.assertEqual(daily_sleep_response.next_token, "next_sleep_token")
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/daily_sleep",
+            f"{self.client.BASE_URL}/usercollection/daily_sleep",
             headers=self.client.headers,
             params={
                 "start_date": start_date_str,
@@ -396,7 +396,7 @@ class TestDailySleep(unittest.TestCase):
         )
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/daily_sleep",
+            f"{self.client.BASE_URL}/usercollection/daily_sleep",
             headers=self.client.headers,
             params={"start_date": start_date_str, "end_date": end_date_str},
 
@@ -456,7 +456,7 @@ class TestDailySleep(unittest.TestCase):
         )
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/daily_sleep/{document_id}",
+            f"{self.client.BASE_URL}/usercollection/daily_sleep/{document_id}",
             headers=self.client.headers,
             params=None,
 
@@ -525,7 +525,7 @@ class TestDailyReadiness(unittest.TestCase):
         )
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/daily_readiness",
+            f"{self.client.BASE_URL}/usercollection/daily_readiness",
             headers=self.client.headers,
             params={
                 "start_date": start_date_str,
@@ -560,7 +560,7 @@ class TestDailyReadiness(unittest.TestCase):
         )
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/daily_readiness",
+            f"{self.client.BASE_URL}/usercollection/daily_readiness",
             headers=self.client.headers,
             params={"start_date": start_date_str, "end_date": end_date_str},
 
@@ -623,7 +623,7 @@ class TestDailyReadiness(unittest.TestCase):
         self.assertEqual(daily_readiness_document.spo2_percentage, 98.5)
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/daily_readiness/{document_id}",
+            f"{self.client.BASE_URL}/usercollection/daily_readiness/{document_id}",
             headers=self.client.headers,
             params=None,
 
@@ -717,7 +717,7 @@ class TestSleep(unittest.TestCase):
         self.assertEqual(sleep_response.next_token, "next_sleep_doc_token")
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/sleep",
+            f"{self.client.BASE_URL}/usercollection/sleep",
             headers=self.client.headers,
             params={
                 "start_date": start_date_str,
@@ -750,7 +750,7 @@ class TestSleep(unittest.TestCase):
         )
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/sleep",
+            f"{self.client.BASE_URL}/usercollection/sleep",
             headers=self.client.headers,
             params={"start_date": start_date_str, "end_date": end_date_str},
 
@@ -801,7 +801,7 @@ class TestSleep(unittest.TestCase):
         )
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/sleep/{document_id}",
+            f"{self.client.BASE_URL}/usercollection/sleep/{document_id}",
             headers=self.client.headers,
             params=None,
 
@@ -863,7 +863,7 @@ class TestSession(unittest.TestCase):
         self.assertEqual(session_response.next_token, "next_session_token")
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/session",
+            f"{self.client.BASE_URL}/usercollection/session",
             headers=self.client.headers,
             params={
                 "start_date": start_date_str,
@@ -898,7 +898,7 @@ class TestSession(unittest.TestCase):
         )
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/session",
+            f"{self.client.BASE_URL}/usercollection/session",
             headers=self.client.headers,
             params={"start_date": start_date_str, "end_date": end_date_str},
 
@@ -946,7 +946,7 @@ class TestSession(unittest.TestCase):
         )
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/session/{document_id}",
+            f"{self.client.BASE_URL}/usercollection/session/{document_id}",
             headers=self.client.headers,
             params=None,
 
@@ -1003,7 +1003,7 @@ class TestTag(unittest.TestCase):
         self.assertEqual(tag_response.next_token, "next_tag_token")
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/tag",
+            f"{self.client.BASE_URL}/usercollection/tag",
             headers=self.client.headers,
             params={
                 "start_date": start_date_str,
@@ -1037,7 +1037,7 @@ class TestTag(unittest.TestCase):
         )
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/tag",
+            f"{self.client.BASE_URL}/usercollection/tag",
             headers=self.client.headers,
             params={"start_date": start_date_str, "end_date": end_date_str},
 
@@ -1078,7 +1078,7 @@ class TestTag(unittest.TestCase):
         )
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/tag/{document_id}",
+            f"{self.client.BASE_URL}/usercollection/tag/{document_id}",
             headers=self.client.headers,
             params=None,
 
@@ -1143,7 +1143,7 @@ class TestWorkout(unittest.TestCase):
         self.assertEqual(workout_response.next_token, "next_workout_token")
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/workout",
+            f"{self.client.BASE_URL}/usercollection/workout",
             headers=self.client.headers,
             params={
                 "start_date": start_date_str,
@@ -1180,7 +1180,7 @@ class TestWorkout(unittest.TestCase):
         )
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/workout",
+            f"{self.client.BASE_URL}/usercollection/workout",
             headers=self.client.headers,
             params={"start_date": start_date_str, "end_date": end_date_str},
 
@@ -1230,7 +1230,7 @@ class TestWorkout(unittest.TestCase):
         )
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/workout/{document_id}",
+            f"{self.client.BASE_URL}/usercollection/workout/{document_id}",
             headers=self.client.headers,
             params=None,
 
@@ -1302,7 +1302,7 @@ class TestEnhancedTag(unittest.TestCase):
         )
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/enhanced_tag",
+            f"{self.client.BASE_URL}/usercollection/enhanced_tag",
             headers=self.client.headers,
             params={
                 "start_date": start_date_str,
@@ -1336,7 +1336,7 @@ class TestEnhancedTag(unittest.TestCase):
         )
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/enhanced_tag",
+            f"{self.client.BASE_URL}/usercollection/enhanced_tag",
             headers=self.client.headers,
             params={"start_date": start_date_str, "end_date": end_date_str},
 
@@ -1384,7 +1384,7 @@ class TestEnhancedTag(unittest.TestCase):
         )
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/enhanced_tag/{document_id}",
+            f"{self.client.BASE_URL}/usercollection/enhanced_tag/{document_id}",
             headers=self.client.headers,
             params=None,
 
@@ -1452,7 +1452,7 @@ class TestDailySpo2(unittest.TestCase):
         self.assertEqual(daily_spo2_response.data[0].spo2_percentage, 97.5)
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/daily_spo2",
+            f"{self.client.BASE_URL}/usercollection/daily_spo2",
             headers=self.client.headers,
             params={
                 "start_date": start_date_str,
@@ -1486,7 +1486,7 @@ class TestDailySpo2(unittest.TestCase):
         )
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/daily_spo2",
+            f"{self.client.BASE_URL}/usercollection/daily_spo2",
             headers=self.client.headers,
             params={"start_date": start_date_str, "end_date": end_date_str},
 
@@ -1530,7 +1530,7 @@ class TestDailySpo2(unittest.TestCase):
         )
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/daily_spo2/{document_id}",
+            f"{self.client.BASE_URL}/usercollection/daily_spo2/{document_id}",
             headers=self.client.headers,
             params=None,
 
@@ -1620,7 +1620,7 @@ class TestSleepTime(unittest.TestCase):
         self.assertEqual(sleep_time_response.data[0].day, date(2024, 3, 10))
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/sleep_time",
+            f"{self.client.BASE_URL}/usercollection/sleep_time",
             headers=self.client.headers,
             params={
                 "start_date": start_date_str,
@@ -1654,7 +1654,7 @@ class TestSleepTime(unittest.TestCase):
         )
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/sleep_time",
+            f"{self.client.BASE_URL}/usercollection/sleep_time",
             headers=self.client.headers,
             params={"start_date": start_date_str, "end_date": end_date_str},
 
@@ -1713,7 +1713,7 @@ class TestSleepTime(unittest.TestCase):
         )
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/sleep_time/{document_id}",
+            f"{self.client.BASE_URL}/usercollection/sleep_time/{document_id}",
             headers=self.client.headers,
             params=None,
 
@@ -1783,7 +1783,7 @@ class TestRestModePeriod(unittest.TestCase):
         )
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/rest_mode_period",
+            f"{self.client.BASE_URL}/usercollection/rest_mode_period",
             headers=self.client.headers,
             params={
                 "start_date": start_date_str,
@@ -1817,7 +1817,7 @@ class TestRestModePeriod(unittest.TestCase):
         )
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/rest_mode_period",
+            f"{self.client.BASE_URL}/usercollection/rest_mode_period",
             headers=self.client.headers,
             params={"start_date": start_date_str, "end_date": end_date_str},
 
@@ -1865,7 +1865,7 @@ class TestRestModePeriod(unittest.TestCase):
         )
 
         mock_get.assert_called_once_with(
-            f"{self.client.BASE_URL}/v2/usercollection/rest_mode_period/{document_id}",
+            f"{self.client.BASE_URL}/usercollection/rest_mode_period/{document_id}",
             headers=self.client.headers,
             params=None,
 
@@ -1897,7 +1897,7 @@ class TestDailyStress(unittest.TestCase):
         response = self.client.daily_stress.get_daily_stress_documents()
         self.assertIsInstance(response, DailyStressResponse)
         mock_get.assert_called_once_with(
-            f"{self.base_url}/v2/usercollection/daily_stress",
+            f"{self.base_url}/usercollection/daily_stress",
             headers=self.client.headers,
             params={},
         )
@@ -1914,7 +1914,7 @@ class TestDailyStress(unittest.TestCase):
             start_date="2024-01-01"
         )
         mock_get.assert_called_once_with(
-            f"{self.base_url}/v2/usercollection/daily_stress",
+            f"{self.base_url}/usercollection/daily_stress",
             headers=self.client.headers,
             params={"start_date": "2024-01-01"},
         )
@@ -1929,7 +1929,7 @@ class TestDailyStress(unittest.TestCase):
 
         self.client.daily_stress.get_daily_stress_documents(end_date="2024-01-31")
         mock_get.assert_called_once_with(
-            f"{self.base_url}/v2/usercollection/daily_stress",
+            f"{self.base_url}/usercollection/daily_stress",
             headers=self.client.headers,
             params={"end_date": "2024-01-31"},
         )
@@ -1946,7 +1946,7 @@ class TestDailyStress(unittest.TestCase):
             start_date="2024-01-01", end_date="2024-01-31"
         )
         mock_get.assert_called_once_with(
-            f"{self.base_url}/v2/usercollection/daily_stress",
+            f"{self.base_url}/usercollection/daily_stress",
             headers=self.client.headers,
             params={"start_date": "2024-01-01", "end_date": "2024-01-31"},
         )
@@ -1963,7 +1963,7 @@ class TestDailyStress(unittest.TestCase):
             next_token="some_token"
         )
         mock_get.assert_called_once_with(
-            f"{self.base_url}/v2/usercollection/daily_stress",
+            f"{self.base_url}/usercollection/daily_stress",
             headers=self.client.headers,
             params={"next_token": "some_token"},
         )
@@ -2001,7 +2001,7 @@ class TestDailyStress(unittest.TestCase):
         self.assertEqual(response.data[0].day_summary, "restored")
         self.assertEqual(response.next_token, "stress_next_token")
         mock_get.assert_called_with(
-            f"{self.base_url}/v2/usercollection/daily_stress",
+            f"{self.base_url}/usercollection/daily_stress",
             headers=self.client.headers,
             params={"start_date": "2024-03-15"},
         )
@@ -2061,7 +2061,7 @@ class TestDailyStress(unittest.TestCase):
         self.assertEqual(response.day_summary, "stressful")
 
         mock_get.assert_called_once_with(
-            f"{self.base_url}/v2/usercollection/daily_stress/{document_id}",
+            f"{self.base_url}/usercollection/daily_stress/{document_id}",
             headers=self.client.headers,
             params=None,  # No params for single document GET
         )
@@ -2095,7 +2095,7 @@ class TestDailyResilience(unittest.TestCase):
         response = self.client.daily_resilience.get_daily_resilience_documents()
         self.assertIsInstance(response, DailyResilienceResponse)
         mock_get.assert_called_once_with(
-            f"{self.base_url}/v2/usercollection/daily_resilience",
+            f"{self.base_url}/usercollection/daily_resilience",
             headers=self.client.headers,
             params={},
         )
@@ -2112,7 +2112,7 @@ class TestDailyResilience(unittest.TestCase):
             start_date="2024-02-01"
         )
         mock_get.assert_called_once_with(
-            f"{self.base_url}/v2/usercollection/daily_resilience",
+            f"{self.base_url}/usercollection/daily_resilience",
             headers=self.client.headers,
             params={"start_date": "2024-02-01"},
         )
@@ -2129,7 +2129,7 @@ class TestDailyResilience(unittest.TestCase):
             end_date="2024-02-28"
         )
         mock_get.assert_called_once_with(
-            f"{self.base_url}/v2/usercollection/daily_resilience",
+            f"{self.base_url}/usercollection/daily_resilience",
             headers=self.client.headers,
             params={"end_date": "2024-02-28"},
         )
@@ -2146,7 +2146,7 @@ class TestDailyResilience(unittest.TestCase):
             start_date="2024-02-01", end_date="2024-02-28"
         )
         mock_get.assert_called_once_with(
-            f"{self.base_url}/v2/usercollection/daily_resilience",
+            f"{self.base_url}/usercollection/daily_resilience",
             headers=self.client.headers,
             params={"start_date": "2024-02-01", "end_date": "2024-02-28"},
         )
@@ -2163,7 +2163,7 @@ class TestDailyResilience(unittest.TestCase):
             next_token="res_token"
         )
         mock_get.assert_called_once_with(
-            f"{self.base_url}/v2/usercollection/daily_resilience",
+            f"{self.base_url}/usercollection/daily_resilience",
             headers=self.client.headers,
             params={"next_token": "res_token"},
         )
@@ -2207,7 +2207,7 @@ class TestDailyResilience(unittest.TestCase):
         self.assertEqual(model_item.level, "solid")
         self.assertEqual(response.next_token, "res_next_token")
         mock_get.assert_called_with(
-            f"{self.base_url}/v2/usercollection/daily_resilience",
+            f"{self.base_url}/usercollection/daily_resilience",
             headers=self.client.headers,
             params={"start_date": "2024-03-18"},
         )
@@ -2274,7 +2274,7 @@ class TestDailyResilience(unittest.TestCase):
         self.assertEqual(response.level, "exceptional")
 
         mock_get.assert_called_once_with(
-            f"{self.base_url}/v2/usercollection/daily_resilience/{document_id}",
+            f"{self.base_url}/usercollection/daily_resilience/{document_id}",
             headers=self.client.headers,
             params=None,
         )
@@ -2312,7 +2312,7 @@ class TestDailyCardiovascularAge(unittest.TestCase):
         )
         self.assertIsInstance(response, DailyCardiovascularAgeResponse)
         mock_get.assert_called_once_with(
-            f"{self.base_url}/v2/usercollection/daily_cardiovascular_age",
+            f"{self.base_url}/usercollection/daily_cardiovascular_age",
             headers=self.client.headers,
             params={},
         )
@@ -2329,7 +2329,7 @@ class TestDailyCardiovascularAge(unittest.TestCase):
             start_date="2024-03-01"
         )
         mock_get.assert_called_once_with(
-            f"{self.base_url}/v2/usercollection/daily_cardiovascular_age",
+            f"{self.base_url}/usercollection/daily_cardiovascular_age",
             headers=self.client.headers,
             params={"start_date": "2024-03-01"},
         )
@@ -2346,7 +2346,7 @@ class TestDailyCardiovascularAge(unittest.TestCase):
             end_date="2024-03-31"
         )
         mock_get.assert_called_once_with(
-            f"{self.base_url}/v2/usercollection/daily_cardiovascular_age",
+            f"{self.base_url}/usercollection/daily_cardiovascular_age",
             headers=self.client.headers,
             params={"end_date": "2024-03-31"},
         )
@@ -2363,7 +2363,7 @@ class TestDailyCardiovascularAge(unittest.TestCase):
             start_date="2024-03-01", end_date="2024-03-31"
         )
         mock_get.assert_called_once_with(
-            f"{self.base_url}/v2/usercollection/daily_cardiovascular_age",
+            f"{self.base_url}/usercollection/daily_cardiovascular_age",
             headers=self.client.headers,
             params={"start_date": "2024-03-01", "end_date": "2024-03-31"},
         )
@@ -2380,7 +2380,7 @@ class TestDailyCardiovascularAge(unittest.TestCase):
             next_token="cva_token"
         )
         mock_get.assert_called_once_with(
-            f"{self.base_url}/v2/usercollection/daily_cardiovascular_age",
+            f"{self.base_url}/usercollection/daily_cardiovascular_age",
             headers=self.client.headers,
             params={"next_token": "cva_token"},
         )
@@ -2419,7 +2419,7 @@ class TestDailyCardiovascularAge(unittest.TestCase):
         self.assertEqual(model_item.vascular_age, 30.5)
         self.assertEqual(response.next_token, "cva_next_token")
         mock_get.assert_called_with(
-            f"{self.base_url}/v2/usercollection/daily_cardiovascular_age",
+            f"{self.base_url}/usercollection/daily_cardiovascular_age",
             headers=self.client.headers,
             params={"start_date": "2024-03-20"},
         )
@@ -2478,7 +2478,7 @@ class TestDailyCardiovascularAge(unittest.TestCase):
         self.assertEqual(response.vascular_age, 32.0)
 
         mock_get.assert_called_once_with(
-            f"{self.base_url}/v2/usercollection/daily_cardiovascular_age/{document_id}",
+            f"{self.base_url}/usercollection/daily_cardiovascular_age/{document_id}",
             headers=self.client.headers,
             params=None,
         )
@@ -2502,7 +2502,7 @@ class TestVo2Max(unittest.TestCase):
 
         self.client = OuraClient(access_token="test_token")
         self.base_url = self.client.BASE_URL
-        self.correct_path_segment = "/v2/usercollection/vO2_max"  # Note the casing
+        self.correct_path_segment = "/usercollection/vO2_max"  # Note the casing
 
     @patch("requests.get")
     def test_get_vo2_max_documents_no_params(self, mock_get):


### PR DESCRIPTION
## Summary
- Fixes issue #8: Remove duplicate `/v2` prefixes in endpoint definitions
- Consolidates URL construction in `OuraClient._make_request` 
- Updates all endpoint modules to use relative paths

## Changes
1. **Updated `OuraClient._make_request`** to handle URL construction centrally:
   - Added logic to ensure endpoints start with `/`
   - Added logic to remove duplicate `/v2` prefixes if present
   - Ensures backward compatibility while fixing the issue

2. **Removed `/v2` prefixes from all endpoint modules**:
   - Updated 17 endpoint files to use relative paths (e.g., `/usercollection/...` instead of `/v2/usercollection/...`)
   - Maintained consistency across all endpoints

3. **Updated all tests** to reflect the URL changes:
   - Modified test expectations to match the new URL construction
   - All 101 tests are now passing

## Test plan
- [x] Run existing test suite: `python -m pytest tests/test_client.py`
- [x] Verify all 101 tests pass
- [x] Manual testing with actual API calls to ensure URLs resolve correctly

Closes #8

🤖 Generated with [Claude Code](https://claude.ai/code)